### PR TITLE
FIX: manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 	"name": "OhMyECH - ECH Indicator",
 	"version": "1.1",
 
-	"description": "Add a visual indication whether a site uses ECH (Encrpted-Client-Hello), or not to the address bar.",
+	"description": "Add a visual indication whether a site uses ECH (Encrypted Client Hello), or not to the address bar.",
 	"icons": {
 		"48": "icons/ech.svg"
 	},

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 	"name": "OhMyECH - ECH Indicator",
 	"version": "1.1",
 
-	"description": "Add a visual indication whether a site uses ECH (Encrypted Client Hello), or not to the address bar.",
+	"description": "Add a visual indication whether a site uses ECH (Encrypted Client Hello) or not to the address bar.",
 	"icons": {
 		"48": "icons/ech.svg"
 	},


### PR DESCRIPTION
Fix typo (Encrpted -> Encrypted), use the official name of the standard by removing hyphens between words, remove comma before "or".